### PR TITLE
Update

### DIFF
--- a/.github/workflows/detect_anomalies.yml
+++ b/.github/workflows/detect_anomalies.yml
@@ -44,8 +44,8 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git add result_anomaly/
             git add detection/detection_output.ipynb
-            git commit -m "🔍 Auto-detect anomalies, update results & notebook"
+            git commit -m "Auto-detect anomalies, update results & notebook"
             git push
           else
-            echo "✅ No anomaly detection changes to commit."
+            echo "No anomaly detection changes to commit."
           fi

--- a/detection/detection.ipynb
+++ b/detection/detection.ipynb
@@ -100,6 +100,7 @@
     "    city_file_map = {\n",
     "        \"Can_Tho\": \"../result/aqi-can-tho_2025.csv\",\n",
     "        \"Da_Nang\": \"../result/aqi-da-nang_2025.csv\",\n",
+    "        \"Hai_Phong\": \"../result/aqi-hai-phong_2025.csv\",\n",
     "        \"Ha_Noi\": \"../result/aqi-hanoi_2025.csv\",\n",
     "        \"Ho_Chi_Minh\": \"../result/aqi-ho-chi-minh-city_2025.csv\",\n",
     "        \"Hue\": \"../result/aqi-hue_2025.csv\",\n",
@@ -215,6 +216,7 @@
     "cities = {\n",
     "    \"Can_Tho\": \"../result/aqi-can-tho_2025.csv\",\n",
     "    \"Da_Nang\": \"../result/aqi-da-nang_2025.csv\",\n",
+    "    \"Hai_Phong\": \"../result/aqi-hai-phong_2025.csv\",\n",
     "    \"Ha_Noi\": \"../result/aqi-hanoi_2025.csv\",\n",
     "    \"Ho_Chi_Minh\": \"../result/aqi-ho-chi-minh-city_2025.csv\",\n",
     "    \"Hue\": \"../result/aqi-hue_2025.csv\",\n",
@@ -247,6 +249,7 @@
     "# Danh sách các file theo thành phố\n",
     "cities = [\n",
     "    (\"Can Tho\", \"../result_anomaly/z_score/can_tho_zscore.csv\", \"../result_anomaly/isolation_forest/anomalies_can_tho_2025.csv\"),\n",
+    "    (\"Hai Phong\", \"../result_anomaly/z_score/hai_phong_zscore.csv\", \"../result_anomaly/isolation_forest/anomalies_hai_phong_2025.csv\"),\n",
     "    (\"Ho Chi Minh\", \"../result_anomaly/z_score/ho_chi_minh_zscore.csv\", \"../result_anomaly/isolation_forest/anomalies_ho_chi_minh_2025.csv\"),\n",
     "    (\"Vinh\", \"../result_anomaly/z_score/vinh_zscore.csv\", \"../result_anomaly/isolation_forest/anomalies_vinh_2025.csv\"),\n",
     "    (\"Nha Trang\", \"../result_anomaly/z_score/nha_trang_zscore.csv\", \"../result_anomaly/isolation_forest/anomalies_nha_trang_2025.csv\"),\n",
@@ -325,7 +328,7 @@
     "    city_name = extract_city_name(file_path).replace(\"_\", \" \").title()\n",
     "    print(f\"\\nPhân tích dữ liệu: {city_name}\")\n",
     "    detect_anomalies_by_zscore(file_path, city_name)\n",
-    "    detect_anomalies(file_path, city_name)\n"
+    "    detect_anomalies(file_path, city_name)"
    ]
   }
  ],


### PR DESCRIPTION
**Tiêu đề:** Thêm Hải Phòng vào quy trình phát hiện bất thường

**Mô tả ngắn:** Bổ sung dữ liệu của Hải Phòng vào quy trình phát hiện bất thường và cập nhật notebook.

**Mô tả chi tiết:**

Pull request này bổ sung thành phố Hải Phòng vào quy trình phát hiện bất thường hiện tại. Các thay đổi bao gồm:

*   Thêm các file dữ liệu AQI của Hải Phòng (`aqi-hai-phong_2025.csv`) vào các mapping thành phố trong notebook `detection/detection.ipynb`.
*   Cập nhật danh sách các thành phố để phân tích và hiển thị kết quả bất thường.
*   Loại bỏ ký tự thừa trong commit message của GitHub workflow.

Mục đích của những thay đổi này là để đảm bảo rằng quy trình phát hiện bất thường bao gồm cả dữ liệu AQI của Hải Phòng, cung cấp một cái nhìn toàn diện hơn về chất lượng không khí trong khu vực. Notebook đã được cập nhật để phản ánh những thay đổi này và đảm bảo kết quả chính xác.
